### PR TITLE
Add initial Tailwind theme

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,9 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Microblog</title>
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=Merriweather+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Montserrat:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&display=swap');
+    </style>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,7 +14,9 @@ import Search from "./Components/Search";
 function App() {
   return (
     <div className="mx-6 mt-4">
-      <h1 className="mb-2 text-3xl font-bold underline">Microblog Frontend</h1>
+      <h1 className="font-heading mb-2 text-3xl font-bold underline">
+        Microblog Frontend
+      </h1>
 
       <Router>
         <Routes>

--- a/frontend/src/Components/Elements/Button.tsx
+++ b/frontend/src/Components/Elements/Button.tsx
@@ -1,0 +1,9 @@
+function Button(props: { children?: React.ReactNode }) {
+  return (
+    <button className="from-primaryFrom to-primaryTo font-heading m-4 rounded-full bg-gradient-to-r px-5 py-2 text-lg font-light text-white drop-shadow-md hover:from-[#EF5030] hover:to-[#F27A25]">
+      {props.children}
+    </button>
+  );
+}
+
+export default Button;

--- a/frontend/src/Components/LogIn.tsx
+++ b/frontend/src/Components/LogIn.tsx
@@ -1,7 +1,12 @@
+import Button from "./Elements/Button";
+
 const LogIn = () => {
-    return(
-        <h2>This is the login page for visitors</h2>
-    );
+  return (
+    <>
+      <h2>This is the login page for visitors</h2>
+      <Button>Log in here!</Button>
+    </>
+  );
 };
 
 export default LogIn;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -5,7 +5,27 @@ export default {
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        heading: "Merriweather Sans, sans-serif",
+        body: "Montserrat, system-ui",
+        sans: "Montserrat, system-ui", // This replaces the document wide default font.
+      },
+      colors: {
+        primary: "#F28B36",
+        primaryFrom: "#EF6140",
+        primaryTo: "#F28B36",
+        secondary: "#9E4DB9",
+        black: "#3F3945",
+        black75: "#6F6B74",
+        black50: "#9F9CA2",
+        black25: "#CFCDD0",
+        white: "#FFFFFF",
+        white75: "#CFCDD0",
+        white50: "#9F9CA2",
+        white25: "#6F6B74",
+      }
+    }
   },
   plugins: [],
 }


### PR DESCRIPTION
This PR adds the initial theme configuration for Tailwind CSS. I also added the web fonts from Google Fonts and a small button example to the login route to show how the themes can be used.