### PR TITLE
TextAreaInput and TagInput optional styling, QoL and style fixes

### DIFF
--- a/frontend/src/Components/Elements/PostModal.tsx
+++ b/frontend/src/Components/Elements/PostModal.tsx
@@ -48,6 +48,7 @@ function PostModal({
             placeholder="Post text..."
             showCount
             maxLength={500}
+            class="min-h-[20rem] w-full"
           />
           <Button
             type="button"
@@ -64,6 +65,7 @@ function PostModal({
             maxTagLength={20}
             maxTags={20}
             showCount
+            class="w-full max-w-[32rem]"
           />
           <div className="flex flex-row gap-4">
             <h5 className="ml-2">Add to group</h5>

--- a/frontend/src/Components/Elements/TagBox.tsx
+++ b/frontend/src/Components/Elements/TagBox.tsx
@@ -7,7 +7,10 @@ type TagBoxProps = {
 
 function TagBox({ text, onDelete }: TagBoxProps) {
   return (
-    <span className="flex h-max flex-row items-center gap-1 rounded-full bg-black25 px-2 dark:bg-white25">
+    <span
+      className="flex h-max flex-row items-center gap-1 rounded-full bg-black25 px-2 dark:bg-white25"
+      onClick={(e) => e.stopPropagation()}
+    >
       #{text}
       <span
         className="cursor-pointer text-black50 hover:text-black75 dark:hover:text-white75"

--- a/frontend/src/Components/Elements/TagInput.tsx
+++ b/frontend/src/Components/Elements/TagInput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import TagBox from "./TagBox";
 
 type TagInputProps = {
@@ -7,6 +7,7 @@ type TagInputProps = {
   maxTags: number;
   maxTagLength: number;
   showCount?: boolean;
+  class?: string;
 };
 
 function TagInput({
@@ -15,9 +16,11 @@ function TagInput({
   maxTags,
   maxTagLength,
   showCount,
+  class: classAdd,
 }: TagInputProps) {
   const [newTag, setNewTag] = useState("");
   const [newTags, setNewTags] = useState(tags);
+  const tagInput = useRef<HTMLInputElement>(null);
 
   const handleTagDelete = (index: number) => {
     // Workaround: toSpliced is a thing, but not supported completely yet.
@@ -36,7 +39,18 @@ function TagInput({
     }
   }, [newTag, newTags, maxTagLength, maxTags]);
   return (
-    <div className="relative flex min-h-[4rem] w-full max-w-[32rem] resize-none flex-row flex-wrap items-baseline gap-1 rounded-xl border border-black50 bg-white p-2 outline-1 focus-within:border-primary focus-within:shadow-[0px_0px_5px_2px_var()] focus-within:shadow-primary focus-within:outline-none hover:border-black75 dark:bg-black dark:hover:border-black25">
+    <div
+      className={
+        "relative flex cursor-text resize-none flex-row flex-wrap items-baseline gap-1 rounded-xl border border-black50 bg-white p-2 outline-1 focus-within:border-primary focus-within:shadow-[0px_0px_5px_2px_var()] focus-within:shadow-primary focus-within:outline-none hover:border-black75 focus-within:hover:border-primary dark:bg-black dark:hover:border-black25" +
+        " " +
+        classAdd
+      }
+      onClick={() => {
+        if (tagInput.current) {
+          tagInput.current.focus();
+        }
+      }}
+    >
       {newTags.map((val, i) => (
         <TagBox text={val} key={i} onDelete={() => handleTagDelete(i)} />
       ))}
@@ -48,9 +62,14 @@ function TagInput({
       <input
         onChange={(e) => setNewTag(e.currentTarget.value)}
         placeholder="Add tag..."
-        className="rounded-none border-0 p-0 hover:border-0 focus:border-0 focus:shadow-none focus:outline-none dark:hover:border-0"
+        className="flex-1 rounded-none border-0 p-0 hover:border-0 focus:border-0 focus:shadow-none focus:outline-none dark:hover:border-0"
         value={newTag}
         maxLength={maxTagLength + 1}
+        ref={tagInput}
+        onKeyDown={(e) => {
+          if (e.key == "Backspace" && !newTag)
+            handleTagDelete(newTags.length - 1);
+        }}
       ></input>
     </div>
   );

--- a/frontend/src/Components/Elements/TextAreaInput.tsx
+++ b/frontend/src/Components/Elements/TextAreaInput.tsx
@@ -1,10 +1,11 @@
-import { useRef, useState } from "react";
+import { useState } from "react";
 
 type TextAreaInputProps = {
   text?: string;
   placeholder?: string;
   maxLength?: number;
   showCount?: boolean;
+  class?: string;
 };
 
 function TextAreaInput({
@@ -12,17 +13,20 @@ function TextAreaInput({
   placeholder,
   maxLength,
   showCount,
+  class: classAdd,
 }: TextAreaInputProps) {
-  const areaRef = useRef<HTMLTextAreaElement>(null);
   const [charCount, setCharCount] = useState(0);
   const [newText, setNewText] = useState(text);
   return (
     <div className="relative">
       <textarea
-        className="min-h-[20rem] w-full resize-none rounded-2xl border border-black50 bg-white px-2 py-1 outline-1 hover:border-black75 focus:border-primary focus:shadow-[0px_0px_5px_2px_var()] focus:shadow-primary focus:outline-none dark:bg-black dark:hover:border-black25"
+        className={
+          "scrollbar-thin resize-none rounded-2xl border border-black50 bg-white px-2 py-1 outline-1 hover:border-black75 focus:border-primary focus:shadow-[0px_0px_5px_2px_var()] focus:shadow-primary focus:outline-none dark:bg-black dark:hover:border-black25" +
+          " " +
+          classAdd
+        }
         placeholder={placeholder}
         maxLength={maxLength}
-        ref={areaRef}
         onChange={(e) => {
           setNewText(e.target.value);
           setCharCount(e.target.value.length);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -92,6 +92,18 @@
       0px 0px 2px #ef6140,
       0px 0px 2px #ef6140;
   }
+  .scrollbar-thin {
+    scrollbar-width: thin;
+  }
+  .scrollbar-thin::-webkit-scrollbar {
+    @apply w-2 bg-transparent;
+  }
+  .scrollbar-thin::-webkit-scrollbar-thumb {
+    @apply rounded-full bg-black50;
+  }
+  .scrollbar-thin::-webkit-scrollbar-track {
+    @apply m-3;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
Added optional style props to TextAreaInput and TagInput. Moved sizing over to PostModal. TagInput now supports backspace erasing of tags. Also made custom thin scrollbar for TextAreaInput.