### PR TITLE
Add settings page components

### DIFF
--- a/frontend/src/Components/Elements/DropdownInput.tsx
+++ b/frontend/src/Components/Elements/DropdownInput.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import MaterialSymbolsExpandMoreRounded from "../Icons/MaterialSymbolsExpandMoreRounded";
 
 type DropdownInputProps = {
@@ -9,6 +9,17 @@ type DropdownInputProps = {
 function DropdownInput({ items, class: classAdd }: DropdownInputProps) {
   const [selected, setSelected] = useState(items[0]);
   const [isOpen, setIsOpen] = useState(false);
+  const dropdownButton = useRef<HTMLInputElement>(null);
+
+  const handleSetIsOpen = (val: boolean) => {
+    // Make the transition have delay only when closing. Couldn't get it to work with just class names.
+    if (dropdownButton.current) {
+      if (isOpen) dropdownButton.current.style.transitionDelay = "200ms";
+      else dropdownButton.current.style.transitionDelay = "0s";
+    }
+    setIsOpen(val);
+  };
+
   return (
     <div
       className={
@@ -18,18 +29,21 @@ function DropdownInput({ items, class: classAdd }: DropdownInputProps) {
       <input
         type="button"
         className={
-          "z-20 rounded-[1.33rem] px-4 py-2 transition-[border-radius] delay-200 duration-0 hover:bg-black25 motion-reduce:delay-0 dark:hover:bg-white25" +
+          "z-20 rounded-[1.33rem] px-4 py-2 transition-[border-radius] duration-0 hover:bg-black25 motion-reduce:delay-0 dark:hover:bg-white25" +
           " " +
-          (isOpen && "rounded-b-none delay-0")
+          (isOpen && "rounded-b-none")
         }
         value={selected}
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={() => {
+          handleSetIsOpen(!isOpen);
+        }}
         onBlur={(e) => {
-          if (!e.relatedTarget) setIsOpen(false);
+          if (!e.relatedTarget) handleSetIsOpen(false);
           else if (document.activeElement === e.target)
             e.target.focus({ preventScroll: true }); // Recapture focus to keep this onBlur working.
         }}
         tabIndex={0}
+        ref={dropdownButton}
       />
       <div
         className="invisible absolute z-10 max-h-0 translate-y-10 overflow-hidden rounded-b-[1.33rem] border border-t-0 border-black50 bg-white transition-all duration-200 ease-in-out motion-reduce:duration-0 dark:bg-black"
@@ -48,7 +62,7 @@ function DropdownInput({ items, class: classAdd }: DropdownInputProps) {
               key={i}
               onClick={() => {
                 setSelected(item);
-                setIsOpen(false);
+                handleSetIsOpen(false);
               }}
             >
               {item}

--- a/frontend/src/Components/Elements/DropdownInput.tsx
+++ b/frontend/src/Components/Elements/DropdownInput.tsx
@@ -1,0 +1,59 @@
+import { useState } from "react";
+import MaterialSymbolsExpandMoreRounded from "../Icons/MaterialSymbolsExpandMoreRounded";
+
+type DropdownInputProps = {
+  items: string[];
+  class?: string;
+};
+
+function DropdownInput({ items, class: classAdd }: DropdownInputProps) {
+  const [selected, setSelected] = useState(items[0]);
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <div
+      className={
+        "relative flex select-none flex-col rounded-[1.33rem]" + " " + classAdd
+      }
+      onClick={() => setIsOpen(!isOpen)}
+    >
+      <input
+        type="button"
+        className={
+          "z-20 rounded-[1.33rem] px-4 py-2 hover:bg-black25 dark:hover:bg-white25" +
+          " " +
+          (isOpen && "rounded-b-none")
+        }
+        value={selected}
+      />
+      <div
+        className="absolute z-10 hidden translate-y-10 overflow-hidden rounded-b-[1.33rem] border border-t-0 border-black50 bg-white dark:bg-black"
+        style={(isOpen && { display: "block" }) || {}}
+      >
+        {items
+          .filter((val) => val !== selected)
+          .map((item, i) => {
+            return (
+              <button
+                className="w-full border-b border-black25 px-4 py-2 first:border-t last:border-b-0 hover:bg-black25 dark:border-white25 dark:hover:bg-white25"
+                key={i}
+                onClick={() => setSelected(item)}
+              >
+                {item}
+              </button>
+            );
+          })}
+      </div>
+      <MaterialSymbolsExpandMoreRounded
+        width={"1.5rem"}
+        height={"1.5rem"}
+        className={
+          "absolute right-2 top-2 z-30 transition-transform duration-100" +
+          " " +
+          (isOpen && "rotate-180")
+        }
+      />
+    </div>
+  );
+}
+
+export default DropdownInput;

--- a/frontend/src/Components/Elements/DropdownInput.tsx
+++ b/frontend/src/Components/Elements/DropdownInput.tsx
@@ -18,9 +18,9 @@ function DropdownInput({ items, class: classAdd }: DropdownInputProps) {
       <input
         type="button"
         className={
-          "z-20 rounded-[1.33rem] px-4 py-2 hover:bg-black25 dark:hover:bg-white25" +
+          "z-20 rounded-[1.33rem] px-4 py-2 transition-[border-radius] delay-200 duration-0 hover:bg-black25 motion-reduce:delay-0 dark:hover:bg-white25" +
           " " +
-          (isOpen && "rounded-b-none")
+          (isOpen && "rounded-b-none delay-0")
         }
         value={selected}
         onClick={() => setIsOpen(!isOpen)}
@@ -32,25 +32,29 @@ function DropdownInput({ items, class: classAdd }: DropdownInputProps) {
         tabIndex={0}
       />
       <div
-        className="absolute z-10 hidden translate-y-10 overflow-hidden rounded-b-[1.33rem] border border-t-0 border-black50 bg-white dark:bg-black"
-        style={(isOpen && { display: "block" }) || {}}
+        className="invisible absolute z-10 max-h-0 translate-y-10 overflow-hidden rounded-b-[1.33rem] border border-t-0 border-black50 bg-white transition-all duration-200 ease-in-out motion-reduce:duration-0 dark:bg-black"
+        style={
+          (isOpen && {
+            visibility: "visible",
+            maxHeight: `calc(${items.length} * 3rem)`,
+          }) ||
+          {}
+        }
       >
-        {items
-          .filter((val) => val !== selected)
-          .map((item, i) => {
-            return (
-              <button
-                className="w-full border-b border-black25 px-4 py-2 last:border-b-0 hover:bg-black25 dark:border-white25 dark:hover:bg-white25"
-                key={i}
-                onClick={() => {
-                  setSelected(item);
-                  setIsOpen(false);
-                }}
-              >
-                {item}
-              </button>
-            );
-          })}
+        {items.map((item, i) => {
+          return (
+            <button
+              className="w-full border-b border-black25 px-4 py-2 last:border-b-0 hover:bg-black25 dark:border-white25 dark:hover:bg-white25"
+              key={i}
+              onClick={() => {
+                setSelected(item);
+                setIsOpen(false);
+              }}
+            >
+              {item}
+            </button>
+          );
+        })}
       </div>
       <MaterialSymbolsExpandMoreRounded
         width={"1.5rem"}

--- a/frontend/src/Components/Elements/DropdownInput.tsx
+++ b/frontend/src/Components/Elements/DropdownInput.tsx
@@ -14,7 +14,6 @@ function DropdownInput({ items, class: classAdd }: DropdownInputProps) {
       className={
         "relative flex select-none flex-col rounded-[1.33rem]" + " " + classAdd
       }
-      onClick={() => setIsOpen(!isOpen)}
     >
       <input
         type="button"
@@ -24,6 +23,13 @@ function DropdownInput({ items, class: classAdd }: DropdownInputProps) {
           (isOpen && "rounded-b-none")
         }
         value={selected}
+        onClick={() => setIsOpen(!isOpen)}
+        onBlur={(e) => {
+          if (!e.relatedTarget) setIsOpen(false);
+          else if (document.activeElement === e.target)
+            e.target.focus({ preventScroll: true }); // Recapture focus to keep this onBlur working.
+        }}
+        tabIndex={0}
       />
       <div
         className="absolute z-10 hidden translate-y-10 overflow-hidden rounded-b-[1.33rem] border border-t-0 border-black50 bg-white dark:bg-black"
@@ -34,9 +40,12 @@ function DropdownInput({ items, class: classAdd }: DropdownInputProps) {
           .map((item, i) => {
             return (
               <button
-                className="w-full border-b border-black25 px-4 py-2 first:border-t last:border-b-0 hover:bg-black25 dark:border-white25 dark:hover:bg-white25"
+                className="w-full border-b border-black25 px-4 py-2 last:border-b-0 hover:bg-black25 dark:border-white25 dark:hover:bg-white25"
                 key={i}
-                onClick={() => setSelected(item)}
+                onClick={() => {
+                  setSelected(item);
+                  setIsOpen(false);
+                }}
               >
                 {item}
               </button>

--- a/frontend/src/Components/Elements/DropdownInput.tsx
+++ b/frontend/src/Components/Elements/DropdownInput.tsx
@@ -26,31 +26,13 @@ function DropdownInput({ items, class: classAdd }: DropdownInputProps) {
         "relative flex select-none flex-col rounded-[1.33rem]" + " " + classAdd
       }
     >
-      <input
-        type="button"
-        className={
-          "rounded-[1.33rem] px-4 py-2 transition-[border-radius] duration-0 hover:bg-black25 motion-reduce:delay-0 dark:hover:bg-white25" +
-          " " +
-          (isOpen && "z-20 rounded-b-none")
-        }
-        value={selected}
-        onClick={() => {
-          handleSetIsOpen(!isOpen);
-        }}
-        onBlur={(e) => {
-          if (!e.relatedTarget) handleSetIsOpen(false);
-          else if (document.activeElement === e.target)
-            e.target.focus({ preventScroll: true }); // Recapture focus to keep this onBlur working.
-        }}
-        tabIndex={0}
-        ref={dropdownButton}
-      />
       <div
         className="invisible absolute z-10 max-h-0 w-full translate-y-10 overflow-hidden rounded-b-[1.33rem] border border-t-0 border-black50 bg-white transition-all duration-200 ease-in-out motion-reduce:duration-0 dark:bg-black"
         style={
           (isOpen && {
             visibility: "visible",
-            maxHeight: `calc(${items.length} * 3rem)`,
+            maxHeight: `calc(${items.length} * 2.6rem)`,
+            zIndex: "20",
           }) ||
           {}
         }
@@ -58,7 +40,7 @@ function DropdownInput({ items, class: classAdd }: DropdownInputProps) {
         {items.map((item, i) => {
           return (
             <button
-              className="w-full border-b border-black25 px-4 py-2 last:border-b-0 hover:bg-black25 dark:border-white25 dark:hover:bg-white25"
+              className="w-full border-b border-black25 px-4 py-2 first:border-t last:border-b-0 hover:bg-black25 dark:border-white25 dark:hover:bg-white25"
               key={i}
               onClick={() => {
                 setSelected(item);
@@ -70,11 +52,31 @@ function DropdownInput({ items, class: classAdd }: DropdownInputProps) {
           );
         })}
       </div>
+      <input
+        type="button"
+        className={
+          "z-10 rounded-[1.33rem] px-4 py-2 transition-[border-radius] duration-0 hover:bg-black25 motion-reduce:delay-0 dark:hover:bg-white25" +
+          " " +
+          (isOpen && "z-20 rounded-b-none")
+        }
+        value={selected}
+        onClick={() => {
+          handleSetIsOpen(!isOpen);
+        }}
+        onBlur={(e) => {
+          if (!e.target.parentElement?.contains(e.relatedTarget))
+            handleSetIsOpen(false);
+          else if (document.activeElement === e.target)
+            e.target.focus({ preventScroll: true }); // Recapture focus to keep this onBlur working.
+        }}
+        tabIndex={0}
+        ref={dropdownButton}
+      />
       <MaterialSymbolsExpandMoreRounded
         width={"1.5rem"}
         height={"1.5rem"}
         className={
-          "absolute right-2 top-2 transition-transform duration-100" +
+          "absolute right-2 top-2 z-10 transition-transform duration-100" +
           " " +
           (isOpen && "z-30 rotate-180")
         }

--- a/frontend/src/Components/Elements/DropdownInput.tsx
+++ b/frontend/src/Components/Elements/DropdownInput.tsx
@@ -29,9 +29,9 @@ function DropdownInput({ items, class: classAdd }: DropdownInputProps) {
       <input
         type="button"
         className={
-          "z-20 rounded-[1.33rem] px-4 py-2 transition-[border-radius] duration-0 hover:bg-black25 motion-reduce:delay-0 dark:hover:bg-white25" +
+          "rounded-[1.33rem] px-4 py-2 transition-[border-radius] duration-0 hover:bg-black25 motion-reduce:delay-0 dark:hover:bg-white25" +
           " " +
-          (isOpen && "rounded-b-none")
+          (isOpen && "z-20 rounded-b-none")
         }
         value={selected}
         onClick={() => {
@@ -46,7 +46,7 @@ function DropdownInput({ items, class: classAdd }: DropdownInputProps) {
         ref={dropdownButton}
       />
       <div
-        className="invisible absolute z-10 max-h-0 translate-y-10 overflow-hidden rounded-b-[1.33rem] border border-t-0 border-black50 bg-white transition-all duration-200 ease-in-out motion-reduce:duration-0 dark:bg-black"
+        className="invisible absolute z-10 max-h-0 w-full translate-y-10 overflow-hidden rounded-b-[1.33rem] border border-t-0 border-black50 bg-white transition-all duration-200 ease-in-out motion-reduce:duration-0 dark:bg-black"
         style={
           (isOpen && {
             visibility: "visible",
@@ -74,9 +74,9 @@ function DropdownInput({ items, class: classAdd }: DropdownInputProps) {
         width={"1.5rem"}
         height={"1.5rem"}
         className={
-          "absolute right-2 top-2 z-30 transition-transform duration-100" +
+          "absolute right-2 top-2 transition-transform duration-100" +
           " " +
-          (isOpen && "rotate-180")
+          (isOpen && "z-30 rotate-180")
         }
       />
     </div>

--- a/frontend/src/Components/Elements/PostContextMenu.tsx
+++ b/frontend/src/Components/Elements/PostContextMenu.tsx
@@ -27,7 +27,8 @@ function PostContextMenu({
           className="rounded-xl border border-black25 px-2 py-1 text-lg hover:border-black50 hover:bg-black25 dark:border-white25 dark:hover:bg-white25"
           onClick={() => setShowMenu(!showMenu)}
           onBlur={(e) => {
-            if (!e.relatedTarget) setShowMenu(false);
+            if (!e.target.parentElement?.contains(e.relatedTarget))
+              setShowMenu(false);
             else if (document.activeElement === e.target)
               e.target.focus({ preventScroll: true }); // Recapture focus to keep this onBlur working.
           }}

--- a/frontend/src/Components/Elements/SettingsPanel.tsx
+++ b/frontend/src/Components/Elements/SettingsPanel.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import MaterialSymbolsExpandMoreRounded from "../Icons/MaterialSymbolsExpandMoreRounded";
 
 type SettingsPanelProps = {
@@ -6,17 +7,58 @@ type SettingsPanelProps = {
 };
 
 function SettingsPanel({ header, children }: SettingsPanelProps) {
+  const [isOpen, setIsOpen] = useState(true);
+  const parent = useRef<HTMLDivElement>(null);
+  const slotsParent = useRef<HTMLDivElement>(null);
+  const slotsTotalHeight = useRef("9999px");
+  useEffect(() => {
+    slotsTotalHeight.current = slotsParent.current
+      ? `${slotsParent.current.childElementCount * 4}rem`
+      : "9999px";
+    console.log(slotsTotalHeight.current);
+  });
+
+  const handleSetIsOpen = (val: boolean) => {
+    if (parent.current) {
+      if (!isOpen) {
+        setTimeout(
+          () => parent.current?.classList.remove("overflow-hidden"),
+          200,
+        );
+      } else parent.current.classList.add("overflow-hidden");
+    }
+    setIsOpen(val);
+  };
+
   return (
-    <div className="min-w-fit rounded-xl border border-black50">
-      <div className="relative flex flex-row items-center justify-center rounded-t-xl bg-black25 hover:bg-black50 dark:bg-white25">
+    <div className="min-w-fit rounded-xl border border-black50" ref={parent}>
+      <div
+        className="relative flex flex-row items-center justify-center rounded-t-xl bg-black25 hover:bg-black50 dark:bg-white25"
+        onClick={() => handleSetIsOpen(!isOpen)}
+      >
         <h3 className="my-2 w-full select-none text-center">{header}</h3>
         <MaterialSymbolsExpandMoreRounded
-          className="absolute right-2"
+          className={
+            "absolute right-2 transition-transform duration-100" +
+            " " +
+            (isOpen && "rotate-180")
+          }
           width={"2.5rem"}
           height={"2.5rem"}
         />
       </div>
-      {children}
+      <div
+        className="max-h-0 transition-[max-height] duration-200"
+        style={
+          (isOpen && {
+            maxHeight: slotsTotalHeight.current,
+          }) ||
+          {}
+        }
+        ref={slotsParent}
+      >
+        {children}
+      </div>
     </div>
   );
 }

--- a/frontend/src/Components/Elements/SettingsPanel.tsx
+++ b/frontend/src/Components/Elements/SettingsPanel.tsx
@@ -1,0 +1,24 @@
+import MaterialSymbolsExpandMoreRounded from "../Icons/MaterialSymbolsExpandMoreRounded";
+
+type SettingsPanelProps = {
+  header: string;
+  children: React.ReactNode;
+};
+
+function SettingsPanel({ header, children }: SettingsPanelProps) {
+  return (
+    <div className="min-w-fit rounded-xl border border-black50">
+      <div className="relative flex flex-row items-center justify-center rounded-t-xl bg-black25 hover:bg-black50 dark:bg-white25">
+        <h3 className="my-2 w-full select-none text-center">{header}</h3>
+        <MaterialSymbolsExpandMoreRounded
+          className="absolute right-2"
+          width={"2.5rem"}
+          height={"2.5rem"}
+        />
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export default SettingsPanel;

--- a/frontend/src/Components/Elements/SettingsPanel.tsx
+++ b/frontend/src/Components/Elements/SettingsPanel.tsx
@@ -15,7 +15,6 @@ function SettingsPanel({ header, children }: SettingsPanelProps) {
     slotsTotalHeight.current = slotsParent.current
       ? `${slotsParent.current.childElementCount * 4}rem`
       : "9999px";
-    console.log(slotsTotalHeight.current);
   });
 
   const handleSetIsOpen = (val: boolean) => {

--- a/frontend/src/Components/Elements/SettingsPanel.tsx
+++ b/frontend/src/Components/Elements/SettingsPanel.tsx
@@ -1,20 +1,35 @@
 import { useEffect, useRef, useState } from "react";
 import MaterialSymbolsExpandMoreRounded from "../Icons/MaterialSymbolsExpandMoreRounded";
+import { useBreakpoint } from "../../Hooks/BreakpointHook";
 
 type SettingsPanelProps = {
   header: string;
   children: React.ReactNode;
+  hSlotHeight?: number;
+  vSlotHeight?: number;
 };
 
-function SettingsPanel({ header, children }: SettingsPanelProps) {
+function SettingsPanel({
+  header,
+  children,
+  hSlotHeight,
+  vSlotHeight,
+}: SettingsPanelProps) {
   const [isOpen, setIsOpen] = useState(true);
   const parent = useRef<HTMLDivElement>(null);
   const slotsParent = useRef<HTMLDivElement>(null);
   const slotsTotalHeight = useRef("9999px");
+  const { isSm } = useBreakpoint("sm");
+
   useEffect(() => {
     slotsTotalHeight.current = slotsParent.current
-      ? `${slotsParent.current.childElementCount * 4}rem`
+      ? `${
+          slotsParent.current.childElementCount *
+          (isSm ? hSlotHeight || 4 : vSlotHeight || 9) // 4 and 9 are the default values.
+        }rem`
       : "9999px";
+    if (isOpen && slotsParent.current)
+      slotsParent.current.style.maxHeight = slotsTotalHeight.current;
   });
 
   const handleSetIsOpen = (val: boolean) => {

--- a/frontend/src/Components/Elements/SettingsSlot.tsx
+++ b/frontend/src/Components/Elements/SettingsSlot.tsx
@@ -1,0 +1,19 @@
+type SettingsSlotProps = {
+  name: string;
+  element: React.ReactNode;
+};
+
+function SettingsSlot({ name, element }: SettingsSlotProps) {
+  return (
+    <div className="flex flex-col items-center border-b border-black25 last:border-b-0 dark:border-white25 sm:flex-row">
+      <div className="my-2 w-[33%] min-w-fit select-none text-center md:text-[1.1rem]">
+        {name}
+      </div>
+      <div className="flex h-full w-full min-w-max flex-1 justify-center border-black25 p-2 dark:border-white25 sm:border-l">
+        {element}
+      </div>
+    </div>
+  );
+}
+
+export default SettingsSlot;

--- a/frontend/src/Components/Elements/ToggleInput.tsx
+++ b/frontend/src/Components/Elements/ToggleInput.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+
+type ToggleInputProps = {
+  onToggle?: (val: boolean) => void;
+  onByDefault?: boolean;
+};
+
+function ToggleInput({ onToggle, onByDefault }: ToggleInputProps) {
+  const [isTrue, setIsTrue] = useState(onByDefault);
+
+  const handleSetIsTrue = (val: boolean) => {
+    setIsTrue(val);
+    if (onToggle) onToggle(val);
+  };
+
+  return (
+    <div
+      className={
+        "h-10 w-20 rounded-full border border-black50 bg-primary bg-opacity-0 transition-all duration-200 ease-in-out" +
+        " " +
+        (isTrue && "bg-opacity-25")
+      }
+      onClick={() => handleSetIsTrue(!isTrue)}
+    >
+      <svg
+        width={"50%"}
+        height={"100%"}
+        viewBox="0 0 16 16"
+        className={
+          "transition-all duration-200 ease-in-out" +
+          " " +
+          (isTrue ? "translate-x-[100%] fill-primary" : "fill-black50")
+        }
+      >
+        <circle r={6} cx={8} cy={8} />
+      </svg>
+    </div>
+  );
+}
+
+export default ToggleInput;

--- a/frontend/src/Components/Icons/MaterialSymbolsExpandMoreRounded.tsx
+++ b/frontend/src/Components/Icons/MaterialSymbolsExpandMoreRounded.tsx
@@ -1,0 +1,8 @@
+import React, { SVGProps } from 'react'
+
+export function MaterialSymbolsExpandMoreRounded(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" {...props}><path fill="currentColor" d="M12 14.95q-.2 0-.375-.062t-.325-.213l-4.6-4.6q-.275-.275-.275-.7t.275-.7q.275-.275.7-.275t.7.275l3.9 3.9l3.9-3.9q.275-.275.7-.275t.7.275q.275.275.275.7t-.275.7l-4.6 4.6q-.15.15-.325.213T12 14.95"></path></svg>
+  )
+}
+export default MaterialSymbolsExpandMoreRounded

--- a/frontend/src/Components/UserSettings.tsx
+++ b/frontend/src/Components/UserSettings.tsx
@@ -1,7 +1,56 @@
+import Button from "./Elements/Button";
+import DropdownInput from "./Elements/DropDownInput";
+import SettingsPanel from "./Elements/SettingsPanel";
+import SettingsSlot from "./Elements/SettingsSlot";
+import TextInput from "./Elements/TextInput";
+
+const mockListOfLocations = [
+  "Finland",
+  "Europe",
+  "North America",
+  "South America",
+  "Middle East",
+  "Africa",
+  "Asia",
+  "Oceania",
+  "Antarctica",
+];
+
 const UserSettings = () => {
-    return(
-        <h2>This is the user's settings page</h2>
-    );
+  return (
+    <div className="m-4 flex flex-col gap-4">
+      <h2 className="my-4 text-center">Settings</h2>
+      <SettingsPanel header="User">
+        <SettingsSlot
+          name="Public Name"
+          element={
+            <div className="flex w-full flex-col gap-2 sm:flex-row">
+              <TextInput class="w-full" />
+              <Button class="btn-primary">Update</Button>
+            </div>
+          }
+        />
+        <SettingsSlot
+          name="Email"
+          element={
+            <div className="flex w-full flex-col gap-2 sm:flex-row">
+              <TextInput class="w-full" />
+              <Button class="btn-primary">Update</Button>
+            </div>
+          }
+        />
+        <SettingsSlot
+          name="Location"
+          element={
+            <div className="flex w-full flex-col gap-2 sm:flex-row">
+              <DropdownInput items={mockListOfLocations} class="w-full" />
+              <Button class="btn-primary">Update</Button>
+            </div>
+          }
+        />
+      </SettingsPanel>
+    </div>
+  );
 };
 
 export default UserSettings;

--- a/frontend/src/Components/UserSettings.tsx
+++ b/frontend/src/Components/UserSettings.tsx
@@ -37,7 +37,8 @@ const UserSettings = () => {
           name="Email"
           element={
             <div className="flex w-full flex-col gap-2 sm:flex-row">
-              <TextInput class="w-full" />
+              <TextInput class="w-full" type="email" />
+
               <Button class="btn-primary">Update</Button>
             </div>
           }

--- a/frontend/src/Components/UserSettings.tsx
+++ b/frontend/src/Components/UserSettings.tsx
@@ -1,5 +1,5 @@
 import Button from "./Elements/Button";
-import DropdownInput from "./Elements/DropDownInput";
+import DropdownInput from "./Elements/DropdownInput";
 import SettingsPanel from "./Elements/SettingsPanel";
 import SettingsSlot from "./Elements/SettingsSlot";
 import TextInput from "./Elements/TextInput";

--- a/frontend/src/Components/UserSettings.tsx
+++ b/frontend/src/Components/UserSettings.tsx
@@ -65,10 +65,14 @@ const UserSettings = () => {
         <SettingsSlot
           name="Dark Mode"
           element={
-            <div className="flex w-full flex-col items-center justify-center gap-3 sm:flex-row">
-              <p>Off</p>
-              <ToggleInput />
-              <p>On</p>
+            <div className="flex w-full flex-row items-center justify-center gap-3">
+              <p className="select-none">Off</p>
+              <ToggleInput
+                onToggle={(val) =>
+                  console.log("Dark mode toggled to state: " + String(val))
+                }
+              />
+              <p className="select-none">On</p>
             </div>
           }
         />

--- a/frontend/src/Components/UserSettings.tsx
+++ b/frontend/src/Components/UserSettings.tsx
@@ -3,6 +3,7 @@ import DropdownInput from "./Elements/DropdownInput";
 import SettingsPanel from "./Elements/SettingsPanel";
 import SettingsSlot from "./Elements/SettingsSlot";
 import TextInput from "./Elements/TextInput";
+import ToggleInput from "./Elements/ToggleInput";
 
 const mockListOfLocations = [
   "Finland",
@@ -15,6 +16,8 @@ const mockListOfLocations = [
   "Oceania",
   "Antarctica",
 ];
+
+const mockListOfLanguages = ["Finnish", "English", "Swedish"];
 
 const UserSettings = () => {
   return (
@@ -45,6 +48,27 @@ const UserSettings = () => {
             <div className="flex w-full flex-col gap-2 sm:flex-row">
               <DropdownInput items={mockListOfLocations} class="w-full" />
               <Button class="btn-primary">Update</Button>
+            </div>
+          }
+        />
+      </SettingsPanel>
+      <SettingsPanel header="Site">
+        <SettingsSlot
+          name="Language"
+          element={
+            <div className="flex w-full flex-col gap-2 sm:flex-row">
+              <DropdownInput items={mockListOfLanguages} class="w-full" />
+              <Button class="btn-primary">Update</Button>
+            </div>
+          }
+        />
+        <SettingsSlot
+          name="Dark Mode"
+          element={
+            <div className="flex w-full flex-col items-center justify-center gap-3 sm:flex-row">
+              <p>Off</p>
+              <ToggleInput />
+              <p>On</p>
             </div>
           }
         />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -63,7 +63,7 @@
   input {
     /* Normal decoration */
     @apply rounded-xl border bg-white px-1 py-1 outline-1 dark:border-black50 dark:bg-black;
-    @apply border-black50 hover:border-black75 focus:border-primary focus:shadow-[0px_0px_5px_2px_var()] focus:shadow-primary focus:outline-none dark:hover:border-black25;
+    @apply border-black50 hover:border-black75 focus:border-primary focus:shadow-[0px_0px_5px_2px] focus:shadow-primary focus:outline-none dark:hover:border-black25;
     /* Invalid decoration */
     @apply invalid:border-warning invalid:bg-warningBg invalid:hover:border-warningHover invalid:focus:border-warningHover invalid:focus:shadow-warning dark:invalid:bg-warningBgDark;
   }


### PR DESCRIPTION
This PR adds the basic components for use on the Settings page, and populates the page with them. The options on the page are temporary and to be filled out later.

There are the new `DropdownInput` and `ToggleInput` available for reuse elsewhere as well. Includes some other fixes too. Might need to tinker more with the new input types if issues arise.