### PR TITLE
Implement theme selecting setting

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import Search from "./Components/Search";
 import Header from "./Components/Header";
 import LeftSidebar from "./Components/LeftSidebar";
 import RightSidebar from "./Components/RightSidebar";
+import { SetTheme } from "./Components/Elements/SettingsElements/ThemeSelector";
 
 const UserLayout = () => {
   return (
@@ -41,6 +42,9 @@ const VisitorLayout = () => {
     </>
   );
 };
+
+// Theme selecting
+SetTheme(localStorage.theme);
 
 function App() {
   return (

--- a/frontend/src/Components/Elements/SettingsElements/ThemeSelector.tsx
+++ b/frontend/src/Components/Elements/SettingsElements/ThemeSelector.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+
+export function SetTheme(theme: Theme | undefined) {
+  switch (theme as Theme | undefined) {
+    case "light":
+      localStorage.theme = "light";
+      document.documentElement.classList.remove("dark");
+      break;
+    case "dark":
+      localStorage.theme = "dark";
+      document.documentElement.classList.add("dark");
+      break;
+    default:
+      if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+        document.documentElement.classList.add("dark");
+      }
+      localStorage.removeItem("theme");
+      break;
+  }
+}
+
+const selectedClassAdd =
+  "outline outline-2 outline-primary z-[1] shadow-[0px_0px_5px_2px] shadow-primary";
+
+function ThemeSelector() {
+  const [currentTheme, setCurrentTheme] = useState<Theme>(
+    localStorage.theme || "system",
+  );
+
+  const handleSetTheme = (theme: Theme) => {
+    setCurrentTheme(theme);
+    SetTheme(theme);
+  };
+
+  return (
+    <div className="flex cursor-pointer select-none flex-row rounded-full border border-black50">
+      <div
+        className={
+          "rounded-l-full border-r border-black25 px-4 py-2 dark:border-white25" +
+          " " +
+          (currentTheme === "system" && selectedClassAdd)
+        }
+        onClick={() => handleSetTheme("system")}
+      >
+        System
+      </div>
+      <div
+        className={
+          "border-black25 bg-white px-4 py-2 text-black dark:border-white25" +
+          " " +
+          (currentTheme === "light" && selectedClassAdd)
+        }
+        onClick={() => handleSetTheme("light")}
+      >
+        Light
+      </div>
+      <div
+        className={
+          "rounded-r-full border-l border-black25 bg-black px-4 py-2 text-white dark:border-white25" +
+          " " +
+          (currentTheme === "dark" && selectedClassAdd)
+        }
+        onClick={() => handleSetTheme("dark")}
+      >
+        Dark
+      </div>
+    </div>
+  );
+}
+
+export default ThemeSelector;

--- a/frontend/src/Components/Elements/SettingsElements/ThemeSelector.tsx
+++ b/frontend/src/Components/Elements/SettingsElements/ThemeSelector.tsx
@@ -33,10 +33,10 @@ function ThemeSelector() {
   };
 
   return (
-    <div className="flex cursor-pointer select-none flex-row rounded-full border border-black50">
+    <div className="flex cursor-pointer select-none flex-row rounded-full">
       <div
         className={
-          "rounded-l-full border-r border-black25 px-4 py-2 dark:border-white25" +
+          "rounded-l-full border border-black50 px-4 py-2 hover:border-black75 hover:bg-black25 dark:border-white25 dark:hover:border-white75 dark:hover:bg-white25" +
           " " +
           (currentTheme === "system" && selectedClassAdd)
         }
@@ -46,7 +46,7 @@ function ThemeSelector() {
       </div>
       <div
         className={
-          "border-black25 bg-white px-4 py-2 text-black dark:border-white25" +
+          "border border-black50 bg-white px-4 py-2 text-black hover:border-black75 hover:bg-black25" +
           " " +
           (currentTheme === "light" && selectedClassAdd)
         }
@@ -56,7 +56,7 @@ function ThemeSelector() {
       </div>
       <div
         className={
-          "rounded-r-full border-l border-black25 bg-black px-4 py-2 text-white dark:border-white25" +
+          "rounded-r-full border border-black50 bg-black px-4 py-2 text-white hover:border-white75 hover:bg-white25" +
           " " +
           (currentTheme === "dark" && selectedClassAdd)
         }

--- a/frontend/src/Components/UserSettings.tsx
+++ b/frontend/src/Components/UserSettings.tsx
@@ -4,13 +4,13 @@ import InfoDot from "./Elements/InfoDot";
 import SettingsPanel from "./Elements/SettingsElements/SettingsPanel";
 import SettingsSlot from "./Elements/SettingsElements/SettingsSlot";
 import TextInput from "./Elements/Inputs/TextInput";
-import ToggleInput from "./Elements/Inputs/ToggleInput";
 import MaterialSymbolsAccountCircle from "./Icons/MaterialSymbolsAccountCircle";
 import MaterialSymbolsPrivacyTipRounded from "./Icons/MaterialSymbolsPrivacyTipRounded";
 import MaterialSymbolsSettingsApplicationsRounded from "./Icons/MaterialSymbolsSettingsApplicationsRounded";
 import { useContext, useState } from "react";
 import { UserContext } from "../UserWrapper";
 import { locationList } from "../globalData";
+import ThemeSelector from "./Elements/SettingsElements/ThemeSelector";
 
 const mockListOfLanguages = ["English", "Finnish"];
 
@@ -151,16 +151,10 @@ const UserSettings = () => {
           }
         />
         <SettingsSlot
-          nameElements={<p>Dark Mode</p>}
+          nameElements={<p>Color Theme</p>}
           element={
             <div className="flex w-full flex-row items-center justify-center gap-3">
-              <p className="select-none">Off</p>
-              <ToggleInput
-                onToggle={(val) =>
-                  console.log("Dark mode toggled to state: " + String(val))
-                }
-              />
-              <p className="select-none">On</p>
+              <ThemeSelector />
             </div>
           }
         />

--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -36,3 +36,5 @@ type Group = {
   recentActivity: Date | "--";
   joinRule: "everyone" | "permission" | "closed";
 };
+
+type Theme = "system" | "light" | "dark";

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -3,6 +3,7 @@ import defaultTheme from 'tailwindcss/defaultTheme'
 
 export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
+  darkMode: "class",
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
This PR adds the theme selection functionality by saving the setting to local storage and a custom `ThemeSelector` settings input to the settings page.

With this merged, the Tailwind dark theme logic works a bit differently and the Chrome dev tools color scheme preference option doesn't apply immediately. It's probably easier just to use the settings page to test dark / light themes from now on. Alternatively you can set the setting to "System" and refresh to use the Chrome dev tools feature.