### PR TITLE
Prisma client version fix

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@oas-tools/core": "^3.1.0",
-        "@prisma/client": "^5.8.0",
+        "@prisma/client": "~5.8.1",
         "@types/uuid": "^9.0.7",
         "connect-pg-simple": "^9.0.1",
         "express": "^4.18.2",
@@ -363,9 +363,9 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.9.0.tgz",
-      "integrity": "sha512-dHvFZgCT0BpRS+gRhk3S+50DstXMmVowxbrPeUJaK7sjNq5OhzfpT/OGE1kq9z5Q8WmOwIXJXyxP8O2CmP+nSg==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.8.1.tgz",
+      "integrity": "sha512-xQtMPfbIwLlbm0VVIVQY2yqQVOxPwRQhvIp7Z3m2900g1bu/zRHKhYZJQWELqmjl6d8YwBy0K2NvMqh47v1ubw==",
       "hasInstallScript": true,
       "engines": {
         "node": ">=16.13"
@@ -533,9 +533,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.13.tgz",
-      "integrity": "sha512-5G4zQwdiQBSWYTDAH1ctw2eidqdhMJaNsiIDKHFr55ihz5Trl2qqR8fdrT732yPBho5gkNxXm67OxWFBqX9aPg==",
+      "version": "20.11.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.15.tgz",
+      "integrity": "sha512-gscmuADZfvNULx1eyirVbr3kVOVZtpQtzKMCZpeSZcN6MfbkRXAR4s9/gsQ4CzxLHw6EStDtKLNtSDL3vbq05A==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2528,9 +2528,9 @@
       ]
     },
     "node_modules/ignore": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
-      "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
       "dev": true,
       "engines": {
         "node": ">= 4"

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/jjarvela/microblog#readme",
   "dependencies": {
     "@oas-tools/core": "^3.1.0",
-    "@prisma/client": "^5.8.0",
+    "@prisma/client": "~5.8.1",
     "@types/uuid": "^9.0.7",
     "connect-pg-simple": "^9.0.1",
     "express": "^4.18.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microblog-backend",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Backend for Microbolg project",
   "main": "index.js",
   "scripts": {
@@ -36,7 +36,6 @@
     "typescript": "^5.3.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.40.1",
     "@types/connect-pg-simple": "^7.0.3",
     "@types/express": "^4.17.21",
     "@types/node": "^20.10.4",


### PR DESCRIPTION
Adding ~ version limit to package.json for regression in 5.9.0 prisma client.