### PR TITLE
Finalize login flow

### DIFF
--- a/api-definition/api-definition.yaml
+++ b/api-definition/api-definition.yaml
@@ -898,7 +898,12 @@ paths:
         - user
       responses:
         "200":
-          $ref: "#/components/responses/OK"
+          description: The registered user's id
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: "a4cbcc87-33a8-4e95-bb97-6afa767e107b"
       requestBody:
         content:
           application/json:

--- a/backend/src/controllers/registrationHandler.ts
+++ b/backend/src/controllers/registrationHandler.ts
@@ -7,14 +7,17 @@ import { UUID, randomUUID } from 'crypto';
 import type { UserRegData, ErrorObject } from "./types"
 import * as argon from "argon2";
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
+import { insertProfile } from '../services/userProfileQueries';
 
 export async function registerUser(c: Context<UserRegData>, req: Request, res: Response
 ) {
   console.log(randomUUID().toString());
   try {
     const userData: UserRegData = c.request.requestBody
+    const newUuid = randomUUID(); // Create uuid to share with profile
+    // Create user
     const result = await insertUser({
-      uid: randomUUID(),
+      uid: newUuid,
       username: userData.userName,
       screen_name: userData.screenName,
       email: userData.email,
@@ -24,6 +27,13 @@ export async function registerUser(c: Context<UserRegData>, req: Request, res: R
       location: userData.location as string,
       disabled: false,
       verified: false
+    })
+    // Create profile
+    await insertProfile({
+      id: randomUUID(),
+      user_id: newUuid,
+      profile_text: "",
+      screen_name: userData.screenName
     })
     req.session.user = { authenticated: true };
     res.status(200).send(result.uid);

--- a/backend/src/controllers/registrationHandler.ts
+++ b/backend/src/controllers/registrationHandler.ts
@@ -13,7 +13,7 @@ export async function registerUser(c: Context<UserRegData>, req: Request, res: R
   console.log(randomUUID().toString());
   try {
     const userData: UserRegData = c.request.requestBody
-    await insertUser({
+    const result = await insertUser({
       uid: randomUUID(),
       username: userData.userName,
       screen_name: userData.screenName,
@@ -25,7 +25,8 @@ export async function registerUser(c: Context<UserRegData>, req: Request, res: R
       disabled: false,
       verified: false
     })
-    res.sendStatus(200);
+    req.session.user = { authenticated: true };
+    res.status(200).send(result.uid);
   } catch (e: unknown) {
     console.log(e);
     if (e instanceof PrismaClientKnownRequestError && e.code === 'P2002') {

--- a/frontend/src/AuthWrapper.tsx
+++ b/frontend/src/AuthWrapper.tsx
@@ -2,6 +2,7 @@ import axios from "axios";
 import { useRef } from "react";
 import Button from "./Components/Elements/Button";
 import { useNavigate } from "react-router";
+import { useUser } from "./UserWrapper";
 
 type AuthWrapperProps = {
   children: React.ReactNode;
@@ -11,10 +12,11 @@ axios.defaults.withCredentials = true;
 axios.interceptors.response.use(
   (res) => res,
   (err) => {
-    if (err.response.status === 401) {
+    if (err.response.status === 401 && window.location.pathname !== "/") {
       (
         document.getElementById("session-expire-dialog") as HTMLDialogElement
       ).showModal();
+      localStorage.removeItem("userId");
       return;
     }
     return err;
@@ -24,6 +26,7 @@ axios.interceptors.response.use(
 function AuthWrapper({ children }: AuthWrapperProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const navigate = useNavigate();
+  const user = useUser();
 
   return (
     <>
@@ -34,12 +37,13 @@ function AuthWrapper({ children }: AuthWrapperProps) {
         className="rounded-xl border border-black50 bg-white p-8 backdrop:bg-[#000] backdrop:opacity-50 dark:border-white50 dark:bg-black dark:text-white"
       >
         <div className="flex flex-col items-center gap-8">
-          <h4>Your session has expired!</h4>
+          <h4>Unauthorized!</h4>
           <Button
             className="btn-primary w-fit"
             onClick={() => {
               navigate("/");
               dialogRef.current?.close();
+              user.onLogout();
             }}
           >
             Return to Login

--- a/frontend/src/Components/Header.tsx
+++ b/frontend/src/Components/Header.tsx
@@ -1,16 +1,37 @@
 import { NavLink } from "react-router-dom";
 import { useBreakpoint } from "../Hooks/BreakpointHook";
+import { Link } from "react-router-dom";
+import { useUser } from "../UserWrapper";
 
 function Header() {
   const { isXs } = useBreakpoint("xs");
+  const { isSm } = useBreakpoint("sm");
+  const user = useUser();
   return (
-    <header className="flex w-full flex-row bg-primary">
-      <h1 className="mx-auto py-2 font-heading text-xl font-bold text-white xs:mx-0 xs:pl-8 sm:text-2xl mid:py-3 mid:text-3xl">
-        <NavLink to={"/"}>
+    <header className="flex w-full flex-row items-center justify-between bg-primary">
+      <h1 className="mx-auto whitespace-nowrap py-2 font-heading text-xl font-bold text-white xs:mx-0 xs:pl-8 sm:text-2xl mid:py-3 mid:text-3xl">
+        <NavLink to={"/home"}>
           <span className="font-light">µB</span>
           {isXs && " Microblog"}
         </NavLink>
       </h1>
+      {user.user && (
+        <div className="flex flex-row items-center gap-4">
+          {isSm && (
+            <div className="flex flex-col">
+              <span className="text-md">Logged in as:</span>
+              <span className="text-md">{user.user?.userName}</span>
+            </div>
+          )}
+          <Link
+            to={"/"}
+            className="mr-5 rounded-xl border border-white bg-white bg-opacity-0 px-3 py-2 transition-all hover:bg-opacity-25"
+            onClick={() => user.onLogout()}
+          >
+            Log out
+          </Link>
+        </div>
+      )}
     </header>
   );
 }

--- a/frontend/src/UserWrapper.tsx
+++ b/frontend/src/UserWrapper.tsx
@@ -30,6 +30,8 @@ interface IUserContext {
     location: string,
     birthday: Date,
   ) => void;
+  loginStatus: "idle" | "loading" | "success" | "fail";
+  setLoginStatus: (status: IUserContext["loginStatus"]) => void;
 }
 
 const UserContext = createContext<IUserContext | null>(null);
@@ -42,6 +44,16 @@ export function useUser() {
 function UserWrapper({ children }: UserWrapperProps) {
   const [currentUid, setCurrentUid] = useState<string | null>(null);
   const [currentUser, setCurrentUser] = useState<User | null>(null);
+  const [loginStatus, setLoginStatus] =
+    useState<IUserContext["loginStatus"]>("idle");
+
+  if (
+    localStorage.getItem("userId") &&
+    typeof localStorage.getItem("userId") === "string" &&
+    currentUid === null
+  ) {
+    setCurrentUid(localStorage.getItem("userId"));
+  }
 
   const loginMutation = useMutation({
     mutationFn: (user: LoginUser) => {
@@ -51,13 +63,19 @@ function UserWrapper({ children }: UserWrapperProps) {
           password: user.password,
         })
         .then((res) => {
+          if (res.status !== 200) throw Error("Login failed!");
           return res.data as string;
         });
     },
-    onError: (error) => console.error(error),
+    onError: (error) => {
+      console.log(error);
+      setLoginStatus("fail");
+    },
     onSuccess: (uid: string) => {
+      setLoginStatus("success");
       socket.emit("add-user", testUserId);
       setCurrentUid(uid);
+      localStorage.setItem("userId", uid);
     },
   });
 
@@ -73,10 +91,20 @@ function UserWrapper({ children }: UserWrapperProps) {
           birthday: user.birthday,
         })
         .then((res) => {
-          return res.data as User;
+          if (res.status !== 200) throw Error("Register failed!");
+          return res.data as string;
         });
     },
-    onError: (error) => console.error(error),
+    onError: (error) => {
+      console.error(error);
+      setLoginStatus("fail");
+    },
+    onSuccess(uid: string) {
+      setLoginStatus("success");
+      setCurrentUid(uid);
+      localStorage.setItem("userId", uid);
+      console.log("Register successful");
+    },
   });
 
   useQuery({
@@ -102,12 +130,15 @@ function UserWrapper({ children }: UserWrapperProps) {
   });
 
   const handleLogin = (username: string, password: string) => {
+    setLoginStatus("loading");
     loginMutation.mutate({ username: username, password: password });
     console.log(socket);
   };
 
-  const handleLogout = async async () => {
+  const handleLogout = async () => {
     socket.disconnect();
+    localStorage.removeItem("userId");
+    setCurrentUid(null);
     setCurrentUser(null);
     try {
       const logoutQuery = await axios.get(`${baseURL}/logout`);
@@ -128,6 +159,12 @@ function UserWrapper({ children }: UserWrapperProps) {
     location: string,
     birthday: Date,
   ) => {
+    setLoginStatus("loading");
+    if (!Date.parse(birthday.toString())) {
+      setLoginStatus("fail");
+      console.log("Invalid date");
+      return;
+    }
     registerMutation.mutate({
       userName: username,
       password: password,
@@ -156,6 +193,8 @@ function UserWrapper({ children }: UserWrapperProps) {
         onLogin: handleLogin,
         onLogout: handleLogout,
         onRegister: handleRegister,
+        loginStatus: loginStatus,
+        setLoginStatus: setLoginStatus,
       }}
     >
       {children}

--- a/frontend/src/UserWrapper.tsx
+++ b/frontend/src/UserWrapper.tsx
@@ -106,9 +106,18 @@ function UserWrapper({ children }: UserWrapperProps) {
     console.log(socket);
   };
 
-  const handleLogout = () => {
+  const handleLogout = async async () => {
     socket.disconnect();
     setCurrentUser(null);
+    try {
+      const logoutQuery = await axios.get(`${baseURL}/logout`);
+      if (logoutQuery.status === 200) {
+        console.log("Logout successful!");
+      }
+    } catch (err) {
+      console.log("Logout failed!");
+      console.error(err);
+    }
   };
 
   const handleRegister = async (

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -13,11 +13,11 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
-        <AuthWrapper>
-          <UserWrapper>
+        <UserWrapper>
+          <AuthWrapper>
             <App />
-          </UserWrapper>
-        </AuthWrapper>
+          </AuthWrapper>
+        </UserWrapper>
       </BrowserRouter>
     </QueryClientProvider>
   </React.StrictMode>,


### PR DESCRIPTION
This PR finalizes the currently planned frontend features for user login / register flow.
- Users can login with existing accounts
- Users can create a new account
- Users can logout
- Users can refresh the site and still be logged in

Changes:
- Creates new logout button that is displayed in the header if logged in.
- Upon login stores userId in localStorage and fetches user info when returning to site.
- Logout deletes the session, states from UserWrapper and localStorage item.
- Manage login status and only let the user on the site if successful. Also displays error messages and disables the login/register button depending on state.
- Creates a linked user profile when creating a user.
- Authenticates the session when registering a new user.
- Prevents user from creating an account without a birthdate specified.