### PR TITLE
Hide frontend groups sections and data to UserProfileInfo

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,8 +5,8 @@ import UserSettings from "./Components/UserSettings";
 import UserNotifications from "./Components/UserNotifications";
 import UserMessages from "./Components/UserMessages";
 import UserFollowing from "./Components/UserFollowing";
-import GroupList from "./Components/GroupList";
-import GroupProfile from "./Components/GroupProfile";
+// import GroupList from "./Components/GroupList";
+// import GroupProfile from "./Components/GroupProfile";
 import Landing from "./Components/Landing";
 import Search from "./Components/Search";
 import Header from "./Components/Header";
@@ -71,8 +71,8 @@ function App() {
           <Route path="/messages/*" element={<UserMessages />} />
           <Route path="/following/*" element={<UserFollowing />} />
           {/*Groups routes*/}
-          <Route path="/groups/*" element={<GroupList />} />
-          <Route path="/groups/profile/:id" element={<GroupProfile />} />
+          {/* <Route path="/groups/*" element={<GroupList />} />
+          <Route path="/groups/profile/:id" element={<GroupProfile />} /> */}
 
           {/*Post routes*/}
           <Route path="/:username/post/:postid" element={<PostPage />} />

--- a/frontend/src/Components/Elements/Modals/PostModal.tsx
+++ b/frontend/src/Components/Elements/Modals/PostModal.tsx
@@ -3,7 +3,7 @@ import Button from "../Button";
 import TagInput from "../Inputs/TagInput";
 import TextAreaInput from "../Inputs/TextAreaInput";
 import MaterialSymbolsAddPhotoAlternateOutlineRounded from "../../Icons/MaterialSymbolsAddPhotoAlternateOutlineRounded";
-import TextInput from "../Inputs/TextInput";
+// import TextInput from "../Inputs/TextInput";
 import UserProfileInfo from "../UserProfileInfo";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import postService from "../../../Services/postService";
@@ -174,13 +174,13 @@ function PostModal({ user, id, text, tags, refObject, mode }: NewPostProps) {
             showCount
             class="w-full max-w-[32rem]"
           />
-          <div className="flex flex-row flex-wrap gap-4">
+          {/* <div className="flex flex-row flex-wrap gap-4">
             <h5 className="ml-2">Add to group</h5>
             <TextInput
               className="w-full min-w-fit flex-1"
               placeholder="Group name..."
             />
-          </div>
+          </div> */}
           <div className="flex flex-row justify-between">
             <Button
               className="btn-secondary"

--- a/frontend/src/Components/Elements/UserProfileInfo.tsx
+++ b/frontend/src/Components/Elements/UserProfileInfo.tsx
@@ -3,6 +3,9 @@ import { ProfilePicture } from "./ProfilePicture";
 import { useRef, useState } from "react";
 import { useUser } from "../../UserWrapper";
 import FollowButton from "./Inputs/FollowButton";
+import { useQuery } from "@tanstack/react-query";
+import userService from "../../Services/userService";
+import profileService from "../../Services/profileService";
 
 type UserProfileInfoProps = {
   user: UserDetails | null;
@@ -26,6 +29,18 @@ function UserProfileInfo({
   const popup = useRef<HTMLDivElement>(null);
   const [floatY, setFloatY] = useState("top-0");
   const [floatX, setFloatX] = useState("left-4");
+
+  const detailQuery = useQuery({
+    queryKey: ["details", user?.id],
+    queryFn: () => userService.getUserDetails(user?.userName || ""),
+    enabled: !!user?.userName,
+  });
+
+  const profileQuery = useQuery({
+    queryKey: ["profile", user?.id],
+    queryFn: () => profileService.getUserProfile(user?.id || ""),
+    enabled: !!user?.id,
+  });
 
   return (
     <div className={"relative z-[90] mr-auto" + " " + classAdd}>
@@ -100,12 +115,29 @@ function UserProfileInfo({
                 </h5>
                 <small>{user?.userName}</small>
               </Link>
-              <p>Fetch user about at some point</p>
-              {/*Add proper follower counts once we get them*/}
-              <div className="bold flex flex-row gap-2 text-lg text-secondary">
-                <p>{user?.followers?.length} Followers</p>
-                <p>{user?.following?.length} Following</p>
-              </div>
+              {detailQuery.data && profileQuery.data && (
+                <>
+                  <p>
+                    {(profileQuery.data as UserProfile).profile_text.substring(
+                      0,
+                      20,
+                    )}
+                    {(profileQuery.data as UserProfile).profile_text.length >
+                      20 && "..."}
+                  </p>
+                  {/*Add proper follower counts once we get them*/}
+                  <div className="bold flex flex-row gap-2 text-lg text-secondary">
+                    <p>
+                      {(detailQuery.data as UserDetails).followers?.length}{" "}
+                      Followers
+                    </p>
+                    <p>
+                      {(detailQuery.data as UserDetails).following?.length}{" "}
+                      Following
+                    </p>
+                  </div>
+                </>
+              )}
             </div>
           </div>
         </div>

--- a/frontend/src/Components/LeftSidebar.tsx
+++ b/frontend/src/Components/LeftSidebar.tsx
@@ -4,7 +4,7 @@ import PostModal from "./Elements/Modals/PostModal";
 import SidebarLink from "./Elements/SidebarLink";
 import MaterialSymbolsAccountCircle from "./Icons/MaterialSymbolsAccountCircle";
 import MaterialSymbolsEditSquareOutlineRounded from "./Icons/MaterialSymbolsEditSquareOutlineRounded";
-import MaterialSymbolsGroupsRounded from "./Icons/MaterialSymbolsGroupsRounded";
+// import MaterialSymbolsGroupsRounded from "./Icons/MaterialSymbolsGroupsRounded";
 import MaterialSymbolsHomeRounded from "./Icons/MaterialSymbolsHomeRounded";
 import MaterialSymbolsMailRounded from "./Icons/MaterialSymbolsMailRounded";
 import MaterialSymbolsNotificationsRounded from "./Icons/MaterialSymbolsNotificationsRounded";
@@ -108,11 +108,11 @@ function LeftSidebar(/*{ unreadCount }: LeftSidebarProps*/) {
                 text="Profile"
                 icon={<MaterialSymbolsAccountCircle />}
               />
-              <SidebarLink
+              {/* <SidebarLink
                 to="/groups"
                 text="Groups"
                 icon={<MaterialSymbolsGroupsRounded />}
-              />
+              /> */}
               <SidebarLink
                 to="/search"
                 text="Search"

--- a/frontend/src/Components/Search.tsx
+++ b/frontend/src/Components/Search.tsx
@@ -169,12 +169,12 @@ const Search = () => {
         >
           People
         </Link>
-        <Link
+        {/* <Link
           to={`/search${query !== "" ? "?q=" + query + "&" : "?"}f=groups`}
           onClick={() => setInnerNav("groups")}
         >
           Groups
-        </Link>
+        </Link> */}
         <Link
           to={`/search${query !== "" ? "?q=" + query + "&" : "?"}f=media`}
           onClick={() => setInnerNav("media")}

--- a/frontend/src/Components/SearchAll.tsx
+++ b/frontend/src/Components/SearchAll.tsx
@@ -1,4 +1,4 @@
-import SearchGroups from "./SearchGroups";
+// import SearchGroups from "./SearchGroups";
 import SearchMedia from "./SearchMedia";
 import SearchPosts from "./SearchPosts";
 import SearchUsers from "./SearchUsers";
@@ -6,21 +6,21 @@ import SearchUsers from "./SearchUsers";
 type SearchAllProps = {
   postResults: Post[];
   userResults: User[];
-  groupResults: Group[];
+  // groupResults: Group[];
   mediaResults: Media[];
 };
 
 export default function SearchAll({
   postResults,
   userResults,
-  groupResults,
+  // groupResults,
   mediaResults,
 }: SearchAllProps) {
   return (
     <>
       <SearchPosts results={postResults} />
       <SearchUsers results={userResults} limit={4} />
-      <SearchGroups results={groupResults} limit={4} />
+      {/* <SearchGroups results={groupResults} limit={4} /> */}
       <SearchMedia results={mediaResults} limit={15} />
     </>
   );

--- a/frontend/src/Components/UserFollowing.tsx
+++ b/frontend/src/Components/UserFollowing.tsx
@@ -1,14 +1,14 @@
 import { Route, Routes, Navigate } from "react-router";
 import FollowedUsers from "./Elements/FollowedUsers";
 import FollowedHashtags from "./Elements/FollowedHashtags";
-import FollowedGroups from "./Elements/FollowedGroups";
+// import FollowedGroups from "./Elements/FollowedGroups";
 import NotFound from "./NotFound";
 import TextInput from "./Elements/Inputs/TextInput";
 import Button from "./Elements/Button";
 import MaterialSymbolsSearchRounded from "./Icons/MaterialSymbolsSearchRounded";
 import TopPageNav from "./Elements/TopPageNav";
 import MaterialSymbolsPerson from "./Icons/MaterialSymbolsPerson";
-import MaterialSymbolsGroupsRounded from "./Icons/MaterialSymbolsGroupsRounded";
+// import MaterialSymbolsGroupsRounded from "./Icons/MaterialSymbolsGroupsRounded";
 import MaterialSymbolsTagRounded from "./Icons/MaterialSymbolsTagRounded";
 
 const UserFollowing = () => {
@@ -20,11 +20,11 @@ const UserFollowing = () => {
           linkName="People"
           icon={MaterialSymbolsPerson}
         />
-        <TopPageNav
+        {/* <TopPageNav
           destination="groups"
           linkName="Groups"
           icon={MaterialSymbolsGroupsRounded}
-        />
+        /> */}
         <TopPageNav
           destination="hashtags"
           linkName="Hashtags"
@@ -44,7 +44,7 @@ const UserFollowing = () => {
         <Routes>
           <Route index element={<Navigate to={"people"} />} />
           <Route path="people" element={<FollowedUsers />} />
-          <Route path="groups" element={<FollowedGroups />} />
+          {/* <Route path="groups" element={<FollowedGroups />} /> */}
           <Route path="hashtags" element={<FollowedHashtags />} />
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/frontend/src/Components/UserTimeline.tsx
+++ b/frontend/src/Components/UserTimeline.tsx
@@ -1,5 +1,5 @@
 import { Routes, Route, Navigate, useParams } from "react-router";
-import FollowedGroups from "./Elements/FollowedGroups";
+// import FollowedGroups from "./Elements/FollowedGroups";
 import FollowedHashtags from "./Elements/FollowedHashtags";
 import FollowedUsers from "./Elements/FollowedUsers";
 import Post from "./Elements/PostElements/Post";
@@ -85,7 +85,7 @@ const UserTimeline = () => {
         <Routes>
           <Route index element={<Navigate to={"following"} />} />
           <Route path="people" element={<FollowedUsers />} />
-          <Route path="groups" element={<FollowedGroups />} />
+          {/* <Route path="groups" element={<FollowedGroups />} /> */}
           <Route path="hashtags" element={<FollowedHashtags />} />
         </Routes>
       </div>


### PR DESCRIPTION
Hides all (I could find) references to groups on the frontend side of the site, by commenting out links/references/paths related to them. Also included a small extra of fetching the correct data for UserProfileInfo popup.