### PR TITLE
Fix the recognized text for icons in ProfileLinkBox to be from the url

### DIFF
--- a/frontend/src/Components/Elements/ProfileElements/ProfileBoxes/ProfileLinkBox.tsx
+++ b/frontend/src/Components/Elements/ProfileElements/ProfileBoxes/ProfileLinkBox.tsx
@@ -154,7 +154,7 @@ function ProfileLinkBox({
                   <span className="flex w-6 flex-row justify-center">
                     {recognizedIconList.reduce(
                       (result, icon) =>
-                        link.text.toLowerCase().includes(icon.find)
+                        link.url.toLowerCase().includes(icon.find)
                           ? icon.icon
                           : result,
                       defaultIcon,


### PR DESCRIPTION
Big fix: `text` -> `url`